### PR TITLE
feature: :building_construction: sbt assembly で jarファイル生成できるようにしたよん♪

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,69 @@
+#
+# Are you tempted to edit this file?
+#
+# First consider if the changes make sense for all,
+# or if they are specific to your workflow/system.
+# If it is the latter, you can augment this list with
+# entries in .git/info/excludes
+#
+# see also test/files/.gitignore
+#
+
+#
+# JARs aren't checked in, they are fetched by sbt
+#
+/lib/*.jar
+/test/files/codelib/*.jar
+/test/files/lib/*.jar
+/test/files/speclib/instrumented.jar
+/tools/*.jar
+
+# Developer specific properties
+/build.properties
+/buildcharacter.properties
+
+# might get generated when testing Jenkins scripts locally
+/jenkins.properties
+
+# target directory for build
+/build/
+
+# other
+/out/
+/bin/
+/sandbox/
+
+# intellij
+/src/intellij*/*.iml
+/src/intellij*/*.ipr
+/src/intellij*/*.iws
+**/.cache
+/.idea
+/.settings
+
+# vscode
+/.vscode
+
+# Standard symbolic link to build/quick/bin
+/qbin
+
+# sbt's target directories
+/target/
+/project/**/target/
+/test/macro-annot/target/
+/test/files/target/
+/test/target/
+/build-sbt/
+local.sbt
+jitwatch.out
+
+# Used by the restarr/restarrFull commands as target directories
+/build-restarr/
+/target-restarr/
+
+# metals
+.metals
+.bloop
+project/**/metals.sbt
+
+.bsp

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.1.3")


### PR DESCRIPTION
## 目的
いぐ社長やjava環境だけある人(Scala環境ない人)にも実行してもらえるようにするための jar ファイルを作成できるようにしました。

## 使い方 (開発者がjarファイルの作る方法)

```console
$ sbt assembly
```
↑これで `target/scala-2.12/config-parse_2.12-0.1.0-SNAPSHOT.jar` のようなファイルができる

## 使い方 (java環境で実行する方法)
```console
java -jar target/scala-2.12/config-parse_2.12-0.1.0-SNAPSHOT.jar
```


## その他
- おまけでgitignoreも導入したぞ