### PR TITLE
Main.scalaでコマンドラインに入力したファイルの行数を標準出力できるようにしました

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,20 +1,6 @@
 /*　
 ●参考にしたサイト↓
 ファイルの出力：http://www.mwsoft.jp/programming/scala/fileread.html
-
-●やること↓
-#14 入力ファイルをコマンドライン引数から取得して、その行数を標準出力する
-入力ファイルをコマンドライン引数から取得して、その行数を標準出力する
-• main関数の中に書いてください
-• コマンドライン引数は main関数の引数の args です
-• scalaでは Source.fromFile("ファイル名") でFileからSourceというデータを取ることができます
-• Sourceの getLinesというメソッドでファイルの中身の全部の行をとることができます
-• length メソッドで長さを取ることができます
-• println(s"行数は $n 行だよ♪") で標準出力します
-確認方法
-sample.config というファイルが手元にあったとして、
-sbt "run sample.config"
-を実行して行数がでたら成功です。
  */
 
 

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,6 +1,32 @@
+/*　
+●参考にしたサイト↓
+ファイルの出力：http://www.mwsoft.jp/programming/scala/fileread.html
+
+●やること↓
+#14 入力ファイルをコマンドライン引数から取得して、その行数を標準出力する
+入力ファイルをコマンドライン引数から取得して、その行数を標準出力する
+• main関数の中に書いてください
+• コマンドライン引数は main関数の引数の args です
+• scalaでは Source.fromFile("ファイル名") でFileからSourceというデータを取ることができます
+• Sourceの getLinesというメソッドでファイルの中身の全部の行をとることができます
+• length メソッドで長さを取ることができます
+• println(s"行数は $n 行だよ♪") で標準出力します
+確認方法
+sample.config というファイルが手元にあったとして、
+sbt "run sample.config"
+を実行して行数がでたら成功です。
+ */
+
+
 object Main {
   def main(args:Array[String]): Unit = {
     val input = "Hello World"
     println(input)
-  }
+    val filename = args(0)  //コマンドラインからファイル名を取得
+    val source = io.Source.fromFile(filename, "utf-8") //ファイルを文字コードUTF-8で出力
+    val lines = source.getLines //Sourceの getLinesというメソッドでファイルの中身の全部の行をとる
+    val lineLength = lines.length //length メソッドでlinesの長さを取る
+    println(s"行数は $lineLength 行だよ♪")
+    source.close
+}
 }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -2,8 +2,6 @@
 ●参考にしたサイト↓
 ファイルの出力：http://www.mwsoft.jp/programming/scala/fileread.html
  */
-
-
 object Main {
   def main(args:Array[String]): Unit = {
     val input = "Hello World"
@@ -14,5 +12,5 @@ object Main {
     val lineLength = lines.length //length メソッドでlinesの長さを取る
     println(s"行数は $lineLength 行だよ♪")
     source.close
-}
+  }
 }


### PR DESCRIPTION
## 目的
ファイルの行数を出力できるようにする。
コマンドラインで指定したファイルだけ行数を出力する。

## 確認方法
user@User MINGW64 ~/work/config-parse/src/main/scala (get_line)
$ sbt "run sample.config"
[warn] No sbt.version set in project/build.properties, base directory: C:\Users\user\work\config-parse\src\main\scala
[info] welcome to sbt 1.8.2 (Oracle Corporation Java 1.8.0_391)
[info] loading global plugins from C:\Users\user\.sbt\1.0\plugins
[info] set current project to scala (in build file:/C:/Users/user/work/config-parse/src/main/scala/)
[info] running Main sample.config
Hello World
行数は 8 行だよ♪
[success] Total time: 1 s, completed 2023/11/09 5:36:54

## 対応issue
https://github.com/ichikawapc/config-parse/issues/14