### PR TITLE
Main.scalaでコマンドライン引数が与えられなかった場合、エラーメッセージを表示できるようにしました

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,16 +1,22 @@
 /*　
 ●参考にしたサイト↓
 ファイルの出力：http://www.mwsoft.jp/programming/scala/fileread.html
+コマンド引数がない時のエラー出力：https://teratail.com/questions/254093
  */
 object Main {
   def main(args:Array[String]): Unit = {
     val input = "Hello World"
     println(input)
-    val filename = args(0)  //コマンドラインからファイル名を取得
-    val source = io.Source.fromFile(filename, "utf-8") //ファイルを文字コードUTF-8で出力
-    val lines = source.getLines //Sourceの getLinesというメソッドでファイルの中身の全部の行をとる
-    val lineLength = lines.length //length メソッドでlinesの長さを取る
-    println(s"行数は $lineLength 行だよ♪")
-    source.close
+    if(args.length == 0) {
+      println("コマンドライン引数を与えて使ってね♡")
+      println("使用例: sbt \"run sample/input/bigip.comf\"")
+    } else {
+      val filename = args(0)  //コマンドラインからファイル名を取得
+      val source = io.Source.fromFile(filename, "utf-8") //ファイルを文字コードUTF-8で出力
+      val lines = source.getLines //Sourceの getLinesというメソッドでファイルの中身の全部の行をとる
+      val lineLength = lines.length //length メソッドでlinesの長さを取る
+      println(s"行数は $lineLength 行だよ♪")
+      source.close
+    }
   }
 }


### PR DESCRIPTION
<概要>
## 目的
コマンドライン引数が与えられなかったときにエラーメッセージを出力できるようにしました

## 確認方法
user@User MINGW64 ~/work/config-parse (parser)
$ sbt run
[info] Loading global plugins from C:\Users\user\.sbt\1.0\plugins
[info] Loading project definition from C:\Users\user\work\config-parse\project
[info] Loading settings for project config-parse from build.sbt ...
[info] Set current project to config-parse (in build file:/C:/Users/user/work/config-parse/)
[info] Running Main
Hello World
コマンドライン引数を与えて使ってね♡
使用例: sbt "run sample/input/bigip.comf"
[success] Total time: 1 s, completed 2023/11/26 6:55:58


## 対応issue
https://github.com/ichikawapc/config-parse/issues/23