### PR TITLE
Main.scalaのエラーメッセージを修正しました

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -9,7 +9,7 @@ object Main {
     println(input)
     if(args.length == 0) {
       println("コマンドライン引数を与えて使ってね♡")
-      println("使用例: sbt \"run sample/input/bigip.comf\"")
+      println("使用例: sbt \"run sample/input/bigip.conf\"")
     } else {
       val filename = args(0)  //コマンドラインからファイル名を取得
       val source = io.Source.fromFile(filename, "utf-8") //ファイルを文字コードUTF-8で出力


### PR DESCRIPTION
<概要>
## 目的
エラーメッセージバグの修正

## 確認方法
user@User MINGW64 ~/work/config-parse (parser2)
$ sbt "run "
[info] Loading global plugins from C:\Users\user\.sbt\1.0\plugins
[info] Loading project definition from C:\Users\user\work\config-parse\project
[info] Loading settings for project config-parse from build.sbt ...
[info] Set current project to config-parse (in build file:/C:/Users/user/work/config-parse/)
[info] Running Main
Hello World
コマンドライン引数を与えて使ってね♡
使用例: sbt "run sample/input/bigip.conf"
[success] Total time: 1 s, completed 2023/11/26 21:57:07

## 対応issue
https://github.com/ichikawapc/config-parse/issues/26