### PR TITLE
Main.scalaで与えられたファイル名が正しくないときに親切なエラーメッセージを出力できるようにしました

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -4,8 +4,6 @@ import scala.util.Try
 ●参考にしたサイト↓
 ファイルの出力：http://www.mwsoft.jp/programming/scala/fileread.html
 コマンド引数がない時のエラー出力：https://teratail.com/questions/254093
-例外処理：https://scala-text.github.io/scala_text/error-handling.html
-例外処理２：http://www.nct9.ne.jp/m_hiroi/java/scala12.html
  */
 object Main {
   def main(args:Array[String]): Unit = {
@@ -16,16 +14,11 @@ object Main {
       println("使用例: sbt \"run sample/input/bigip.conf\"")
     } else {
       val filename = (args(0))  //コマンドラインからファイル名を取得
-      try {
-        val source = io.Source.fromFile(filename, "utf-8") //ファイルを文字コードUTF-8で出力
-        val lines = source.getLines //Sourceの getLinesというメソッドでファイルの中身の全部の行をとる
-        val lineLength = lines.length //length メソッドでlinesの長さを取る
-        println(s"行数は $lineLength 行だよ♪")
-        source.close
-      } catch {
-        case e: java.io.FileNotFoundException =>  //「java.io.FileNotFoundException」というエラーコードをキャッチ
-          println(s"$filename は存在しません")  
-      }
+      val source = io.Source.fromFile(filename, "utf-8") //ファイルを文字コードUTF-8で出力
+      val lines = source.getLines //Sourceの getLinesというメソッドでファイルの中身の全部の行をとる
+      val lineLength = lines.length //length メソッドでlinesの長さを取る
+      println(s"行数は $lineLength 行だよ♪")
+      source.close
     }
   }
 }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,7 +1,11 @@
+import scala.util.Try
+
 /*　
 ●参考にしたサイト↓
 ファイルの出力：http://www.mwsoft.jp/programming/scala/fileread.html
 コマンド引数がない時のエラー出力：https://teratail.com/questions/254093
+例外処理：https://scala-text.github.io/scala_text/error-handling.html
+例外処理２：http://www.nct9.ne.jp/m_hiroi/java/scala12.html
  */
 object Main {
   def main(args:Array[String]): Unit = {
@@ -11,12 +15,17 @@ object Main {
       println("コマンドライン引数を与えて使ってね♡")
       println("使用例: sbt \"run sample/input/bigip.conf\"")
     } else {
-      val filename = args(0)  //コマンドラインからファイル名を取得
-      val source = io.Source.fromFile(filename, "utf-8") //ファイルを文字コードUTF-8で出力
-      val lines = source.getLines //Sourceの getLinesというメソッドでファイルの中身の全部の行をとる
-      val lineLength = lines.length //length メソッドでlinesの長さを取る
-      println(s"行数は $lineLength 行だよ♪")
-      source.close
+      val filename = (args(0))  //コマンドラインからファイル名を取得
+      try {
+        val source = io.Source.fromFile(filename, "utf-8") //ファイルを文字コードUTF-8で出力
+        val lines = source.getLines //Sourceの getLinesというメソッドでファイルの中身の全部の行をとる
+        val lineLength = lines.length //length メソッドでlinesの長さを取る
+        println(s"行数は $lineLength 行だよ♪")
+        source.close
+      } catch {
+        case e: java.io.FileNotFoundException =>  //「java.io.FileNotFoundException」というエラーコードをキャッチ
+          println(s"$filename は存在しません")  
+      }
     }
   }
 }

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,9 +1,10 @@
 import scala.util.Try
-
 /*　
 ●参考にしたサイト↓
 ファイルの出力：http://www.mwsoft.jp/programming/scala/fileread.html
 コマンド引数がない時のエラー出力：https://teratail.com/questions/254093
+例外処理：https://scala-text.github.io/scala_text/error-handling.html
+例外処理２：http://www.nct9.ne.jp/m_hiroi/java/scala12.html
  */
 object Main {
   def main(args:Array[String]): Unit = {
@@ -14,11 +15,16 @@ object Main {
       println("使用例: sbt \"run sample/input/bigip.conf\"")
     } else {
       val filename = (args(0))  //コマンドラインからファイル名を取得
-      val source = io.Source.fromFile(filename, "utf-8") //ファイルを文字コードUTF-8で出力
-      val lines = source.getLines //Sourceの getLinesというメソッドでファイルの中身の全部の行をとる
-      val lineLength = lines.length //length メソッドでlinesの長さを取る
-      println(s"行数は $lineLength 行だよ♪")
-      source.close
+      try {
+        val source = io.Source.fromFile(filename, "utf-8") //ファイルを文字コードUTF-8で出力
+        val lines = source.getLines //Sourceの getLinesというメソッドでファイルの中身の全部の行をとる
+        val lineLength = lines.length //length メソッドでlinesの長さを取る
+        println(s"行数は $lineLength 行だよ♪")
+        source.close
+      } catch {
+        case e: java.io.FileNotFoundException =>  //「java.io.FileNotFoundException」というエラーコードをキャッチ
+          println(s"$filename は存在しません")
+      }
     }
   }
 }


### PR DESCRIPTION
<概要>
## 目的
ファイル名が正しくないときに「(ファイル名)は存在しません」と親切なエラーメッセージが出力されるようにしました

## 確認方法
user@User MINGW64 ~/work/config-parse (parser2)
$ sbt "run sample2.config"
[info] Loading global plugins from C:\Users\user\.sbt\1.0\plugins
[info] Loading project definition from C:\Users\user\work\config-parse\project
[info] Loading settings for project config-parse from build.sbt ...
[info] Set current project to config-parse (in build file:/C:/Users/user/work/config-parse/)
[info] Compiling 1 Scala source to C:\Users\user\work\config-parse\target\scala-2.12\classes ...
[info] Done compiling.
[info] Packaging C:\Users\user\work\config-parse\target\scala-2.12\config-parse_2.12-0.1.0.jar ...
[info] Done packaging.
[info] Running Main sample2.config
Hello World
sample2.config は存在しません
[success] Total time: 6 s, completed 2023/11/27 22:35:36

## 対応issue
https://github.com/ichikawapc/config-parse/issues/27