### PR TITLE
Section.scalaでリストをセクション名ごとにまとめるメソッドをつくりました

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -9,7 +9,14 @@ import scala.util.Try
 object Main {
   def main(args:Array[String]): Unit = {
     val input = "Hello World"
+    val inputData = List(
+      ("foo", Item("default", Map("report-name" -> "Summary"))),
+      ("bar", Item("monitor", Map("rule" -> "none"))),
+      ("foo", Item("report2", Map("report-name" -> "Common", "user" -> "admin")))
+    )
     println(input)
+    val outputData = Section.groupItems(inputData)
+    println(outputData)
     if(args.length == 0) {
       println("コマンドライン引数を与えて使ってね♡")
       println("使用例: sbt \"run sample/input/bigip.conf\"")

--- a/src/main/scala/Section.scala
+++ b/src/main/scala/Section.scala
@@ -1,13 +1,14 @@
-import com.sun.tools.javac.jvm.Items
-case class Section(name: String, attributes: List[String], itemList: List[Item])
+case class Section(name : String,
+                   fieldNames : List[String],
+                   items : List[Item])
 
 object Section {
   def groupItems(items: List[(String, Item)]): List[Section] = {
     items.groupBy(_._1).map {
       case (sectionName, itemLists) =>
-        val sectionAttributes = itemLists.flatMap(_._2.cacontents.keys).distinct.toList
+        val sectionFieldNames = itemLists.flatMap(_._2.cacontents.keys).distinct.toList
         val sectionItems = itemLists.map(_._2)
-        Section(sectionName, sectionAttributes, sectionItems)
+        Section(sectionName, sectionFieldNames, sectionItems)
     }.toList
   }
 }

--- a/src/main/scala/Section.scala
+++ b/src/main/scala/Section.scala
@@ -1,3 +1,13 @@
-case class section(name : String,
-                   fieldNames : List[String],
-                   items : List[Item])
+import com.sun.tools.javac.jvm.Items
+case class Section(name: String, attributes: List[String], itemList: List[Item])
+
+object Section {
+  def groupItems(items: List[(String, Item)]): List[Section] = {
+    items.groupBy(_._1).map {
+      case (sectionName, itemLists) =>
+        val sectionAttributes = itemLists.flatMap(_._2.cacontents.keys).distinct.toList
+        val sectionItems = itemLists.map(_._2)
+        Section(sectionName, sectionAttributes, sectionItems)
+    }.toList
+  }
+}


### PR DESCRIPTION
## 目的
リストをセクション名ごとにまとめられるようにする

## 確認方法
user@User MINGW64 ~/work/config-parse (make_section)
$ sbt run
[info] Loading global plugins from C:\Users\user\.sbt\1.0\plugins
[info] Loading settings for project config-parse-build from plugins.sbt ...
[info] Loading project definition from C:\Users\user\work\config-parse\project
[info] Loading settings for project config-parse from build.sbt ...
[info] Set current project to config-parse (in build file:/C:/Users/user/work/config-parse/)
[info] Compiling 1 Scala source to C:\Users\user\work\config-parse\target\scala-2.12\classes ...
[info] Done compiling.
[info] Compiling 1 Scala source to C:\Users\user\work\config-parse\target\scala-2.12\classes ...
[info] Done compiling.
[info] Packaging C:\Users\user\work\config-parse\target\scala-2.12\config-parse_2.12-0.1.0.jar ...
[info] Done packaging.
[info] Running Main
Hello World
List(Section(foo,List(report-name, user),List(Item(default,Map(report-name -> Summary)), Item(report2,Map(report-name -> Common, user -> admin)))), Section(bar,List(rule),List(Item(monitor,Map(rule -> none)))))
コマンドライン引数を与えて使ってね♡
使用例: sbt "run sample/input/bigip.conf"
[success] Total time: 6 s, completed 2023/12/10 23:37:36

## 関連 issue (ある場合は)
* https://github.com/ichikawapc/config-parse/issues/32