### PR TITLE
Parser.scalaでセッション名などをパースできるようにしました

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -14,8 +14,10 @@ object Main {
       ("bar", Item("monitor", Map("rule" -> "none"))),
       ("foo", Item("report2", Map("report-name" -> "Common", "user" -> "admin")))
     )
-    val testInput = "a bc defg"
-    println(Parser.run(testInput))
+    val testInput1 = "a bc defg"
+    val testInput2 = "ltm node /Common/SL00300 {"
+    println(Parser.run(testInput1))
+    println(Parser.run(testInput2))
     println(input)
     val outputData = Section.groupItems(inputData)
     println(outputData)

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -14,6 +14,8 @@ object Main {
       ("bar", Item("monitor", Map("rule" -> "none"))),
       ("foo", Item("report2", Map("report-name" -> "Common", "user" -> "admin")))
     )
+    val testInput = "a bc defg"
+    println(Parser.run(testInput))
     println(input)
     val outputData = Section.groupItems(inputData)
     println(outputData)

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -1,4 +1,18 @@
+/*
+参考にしたサイト↓
+正規表現：https://qiita.com/haryon0103/items/dffbe5333be1fc8a6908
+ */
+
 import scala.util.parsing.combinator._
+import scala.util.matching.Regex
 
 object Parser extends RegexParsers {
+  override def skipWhitespace = true
+
+  def name: Regex =  "[0-9a-zA-Z/:-_.,]".r
+
+  def names: Parser[List[String]] = name.*
+
+  def run(text: String):ParseResult[List[String]] = parse(names, text)
+
 }

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -8,11 +8,7 @@ import scala.util.matching.Regex
 
 object Parser extends RegexParsers {
   override def skipWhitespace = true
-
-  def name: Regex =  "[0-9a-zA-Z/:-_.,]".r
-
+  def name: Regex =  """[0-9a-zA-Z/:-_.,]+""".r
   def names: Parser[List[String]] = name.*
-
   def run(text: String):ParseResult[List[String]] = parse(names, text)
-
 }


### PR DESCRIPTION
<概要>

## 目的
セッション名などをパースする

## 確認方法
sbt:config-parse> run
[info] Compiling 2 Scala sources to C:\Users\user\work\config-parse\target\scala-2.12\classes ...
[info] Done compiling.
[info] Packaging C:\Users\user\work\config-parse\target\scala-2.12\config-parse_2.12-0.1.0.jar ...
[info] Done packaging.
[info] Running Main
[1.10] parsed: List(a, bc, defg)
[1.25] parsed: List(ltm, node, /Common/SL00300)
Hello World
List(Section(foo,List(report-name, user),List(Item(default,Map(report-name -> Summary)), Item(report2,Map(report-name -> Common, user -> admin)))), Section(bar,List(rule),List(Item(monitor,Map(rule -> none)))))
コマンドライン引数を与えて使ってね♡
使用例: sbt "run sample/input/bigip.conf"
[success] Total time: 8 s, completed 2023/12/27 20:51:21

## 関連 issue (ある場合は)
* https://github.com/ichikawapc/config-parse/issues/34