### PR TITLE
#31の編集

### DIFF
--- a/src/main/scala/Item.scala
+++ b/src/main/scala/Item.scala
@@ -1,2 +1,2 @@
 case class Item(name :String,
-                cacontents : Map[String, String])
+                contents : Map[String, String])

--- a/src/main/scala/Section.scala
+++ b/src/main/scala/Section.scala
@@ -6,7 +6,7 @@ object Section {
   def groupItems(items: List[(String, Item)]): List[Section] = {
     items.groupBy(_._1).map {
       case (sectionName, itemLists) =>
-        val sectionFieldNames = itemLists.flatMap(_._2.cacontents.keys).distinct.toList
+        val sectionFieldNames = itemLists.flatMap(_._2.contents.keys).distinct.toList
         val sectionItems = itemLists.map(_._2)
         Section(sectionName, sectionFieldNames, sectionItems)
     }.toList


### PR DESCRIPTION
## 目的
item.scalaの"cacontents"を"contents"に修正しました。
【1/5追記】コンパイルエラー解消の為、Section.scalaの"val sectionFieldNames"を修正しました。

## 確認方法
修正前↓
![スクリーンショット 2023-12-31 154939](https://github.com/ichikawapc/config-parse/assets/143084216/51a9335d-1dda-43f7-8814-a439db906165)
修正後↓
![スクリーンショット 2024-01-05 152158](https://github.com/ichikawapc/config-parse/assets/143084216/eca98bae-3241-4694-a84f-0c1e5a52a3bb)

## 関連issue
https://github.com/ichikawapc/config-parse/issues/31