### PR TITLE
Parser.scalaでItemのコンテンツを1つパースできるようにしました

### DIFF
--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -22,11 +22,12 @@ object Main {
 
     //val testInput1 = "a bc defg"
     //val testInput2 = "ltm node /Common/SL00300 {"
-    val testInput3 = "availability-zone {\n" +
-      "valid-values { a b c d }\n" +
-      "}"
+    val testInput3 =
+    """
+      default-report {\n    report-name sessionReports/sessionSummary\n    user /Common/admin\n}""".stripMargin
     //val testRun = Parser.run(testInput2)
-    val testParserContent = Parser.content(new CharSequenceReader(testInput3))
+    //val testParserContent = Parser.content(new CharSequenceReader(testInput3))
+    val testParserContent = Parser.parse(Parser.content, testInput3)
     println(testParserContent)
 
     if(args.length == 0) {

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -22,13 +22,15 @@ object Main {
 
     val testInput1 = "user /Common/admin"
     val testInput2 =
-      """
-     availability-zone {
-            valid-values { a b c d }
-      }
-}""".stripMargin
-    val testSimpleContent = Parser.content(new CharSequenceReader(testInput1))
-    val testBlockContent = Parser.content(new CharSequenceReader(testInput2))
+      """availability-zone {
+      valid-values { a b c d }
+      }""".stripMargin
+
+    val testSimpleContent = Parser.parse(Parser.content, testInput1)
+    val testBlockContent = Parser.parse(Parser.content, testInput2)
+
+    //val testSimpleContent = Parser.content(new CharSequenceReader(testInput1))
+    //val testBlockContent = Parser.content(new CharSequenceReader(testInput2))
     println(testSimpleContent)
     println(testBlockContent)
 

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,4 +1,5 @@
 import scala.util.Try
+import scala.util.parsing.input.CharSequenceReader
 /*　
 ●参考にしたサイト↓
 ファイルの出力：http://www.mwsoft.jp/programming/scala/fileread.html
@@ -19,10 +20,14 @@ object Main {
     val outputData = Section.groupItems(inputData)
     println(outputData)
 
-    val testInput1 = "a bc defg"
+    //val testInput1 = "a bc defg"
     //val testInput2 = "ltm node /Common/SL00300 {"
+    val testInput3 = "availability-zone {\n" +
+      "valid-values { a b c d }\n" +
+      "}"
     //val testRun = Parser.run(testInput2)
-    val testParserContent = Parser.content(testInput1)
+    val testParserContent = Parser.content(new CharSequenceReader(testInput3))
+    println(testParserContent)
 
     if(args.length == 0) {
       println("コマンドライン引数を与えて使ってね♡")

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -20,11 +20,9 @@ object Main {
     println(outputData)
 
     val testInput1 = "a bc defg"
-    val testInput2 = "ltm node /Common/SL00300 {"
-    val testRun = Parser.run(testInput2)
-    println(testRun)
-   // val testContent = Parser.content(testRun)
-    //println(testContent)
+    //val testInput2 = "ltm node /Common/SL00300 {"
+    //val testRun = Parser.run(testInput2)
+    val testParserContent = Parser.content(testInput1)
 
     if(args.length == 0) {
       println("コマンドライン引数を与えて使ってね♡")

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -21,6 +21,9 @@ object Main {
     println(input)
     val outputData = Section.groupItems(inputData)
     println(outputData)
+    val testParser1 = "user /Common/admin"
+    val runTestParser1 = Parser.run(testInput1)
+    println(Parser.content(runTestParser1))
     if(args.length == 0) {
       println("コマンドライン引数を与えて使ってね♡")
       println("使用例: sbt \"run sample/input/bigip.conf\"")

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -1,5 +1,6 @@
-import scala.util.Try
-import scala.util.parsing.input.CharSequenceReader
+//import scala.util.{Failure, Success}
+//import scala.util.parsing.combinator.Parsers
+
 /*　
 ●参考にしたサイト↓
 ファイルの出力：http://www.mwsoft.jp/programming/scala/fileread.html
@@ -23,16 +24,13 @@ object Main {
     val testInput1 = "user /Common/admin"
     val testInput2 =
       """availability-zone {
-      valid-values { a b c d }
+      valid-values
       }""".stripMargin
 
-    val testSimpleContent = Parser.parse(Parser.content, testInput1)
-    val testBlockContent = Parser.parse(Parser.content, testInput2)
-
-    //val testSimpleContent = Parser.content(new CharSequenceReader(testInput1))
-    //val testBlockContent = Parser.content(new CharSequenceReader(testInput2))
-    println(testSimpleContent)
-    println(testBlockContent)
+    Parser.parse(Parser.content, testInput2) match {
+      case Parser.Success(r, _next) => println(r)
+      case Parser.Failure(e, _next) => println(s"残念: ${e.toString()}")
+    }
 
     if(args.length == 0) {
       println("コマンドライン引数を与えて使ってね♡")

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -21,15 +21,20 @@ object Main {
     val outputData = Section.groupItems(inputData)
     println(outputData)
 
-    val testInput1 = "user /Common/admin"
+    val testInput1 = """user /Common/admin"""
     val testInput2 =
-      """availability-zone {
-            valid-values { a b c d }
-        }"""
-
-    Parser.parse(Parser.content, testInput2) match {
+      """default-report {
+    report-name sessionReports/sessionSummary
+    }"""
+    Parser.parse(Parser.field, testInput1) match {
       case Parser.Success(r, _next) => println(r)
       case Parser.Failure(e, _next) => println(s"残念: ${e.toString()}")
+      case Parser.Error(e, _next) => println(s"エラー: ${e.toString()}")
+    }
+    Parser.parse(Parser.field, testInput2) match {
+      case Parser.Success(r, _next) => println(r)
+      case Parser.Failure(e, _next) => println(s"残念: ${e.toString()}")
+      case Parser.Error(e, _next) => println(s"エラー: ${e.toString()}")
     }
 
     if(args.length == 0) {

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -25,6 +25,7 @@ object Main {
     val testInput2 =
       """default-report {
     report-name sessionReports/sessionSummary
+    user /Common/admin
     }"""
     Parser.parse(Parser.field, testInput1) match {
       case Parser.Success(r, _next) => println(r)

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -24,10 +24,13 @@ object Main {
     //val testInput2 = "ltm node /Common/SL00300 {"
     val testInput3 =
     """
-      default-report {\n    report-name sessionReports/sessionSummary\n    user /Common/admin\n}""".stripMargin
+      apm report default-report {
+    report-name sessionReports/sessionSummary
+    user /Common/admin
+}""".stripMargin
     //val testRun = Parser.run(testInput2)
     //val testParserContent = Parser.content(new CharSequenceReader(testInput3))
-    val testParserContent = Parser.parse(Parser.content, testInput3)
+    val testParserContent = Parser.content(new CharSequenceReader(testInput3))
     println(testParserContent)
 
     if(args.length == 0) {

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -9,21 +9,23 @@ import scala.util.Try
 object Main {
   def main(args:Array[String]): Unit = {
     val input = "Hello World"
+    println(input)
+
     val inputData = List(
       ("foo", Item("default", Map("report-name" -> "Summary"))),
       ("bar", Item("monitor", Map("rule" -> "none"))),
       ("foo", Item("report2", Map("report-name" -> "Common", "user" -> "admin")))
     )
-    val testInput1 = "a bc defg"
-    val testInput2 = "ltm node /Common/SL00300 {"
-    println(Parser.run(testInput1))
-    println(Parser.run(testInput2))
-    println(input)
     val outputData = Section.groupItems(inputData)
     println(outputData)
-    val testParser1 = "user /Common/admin"
-    val runTestParser1 = Parser.run(testInput1)
-    println(Parser.content(runTestParser1))
+
+    val testInput1 = "a bc defg"
+    val testInput2 = "ltm node /Common/SL00300 {"
+    val testRun = Parser.run(testInput2)
+    println(testRun)
+    val testContent = Parser.content(testRun)
+    println(testContent)
+
     if(args.length == 0) {
       println("コマンドライン引数を与えて使ってね♡")
       println("使用例: sbt \"run sample/input/bigip.conf\"")

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -23,8 +23,8 @@ object Main {
     val testInput2 = "ltm node /Common/SL00300 {"
     val testRun = Parser.run(testInput2)
     println(testRun)
-    val testContent = Parser.content(testRun)
-    println(testContent)
+   // val testContent = Parser.content(testRun)
+    //println(testContent)
 
     if(args.length == 0) {
       println("コマンドライン引数を与えて使ってね♡")

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -24,8 +24,8 @@ object Main {
     val testInput1 = "user /Common/admin"
     val testInput2 =
       """availability-zone {
-      valid-values
-      }""".stripMargin
+            valid-values { a b c d }
+        }"""
 
     Parser.parse(Parser.content, testInput2) match {
       case Parser.Success(r, _next) => println(r)

--- a/src/main/scala/Main.scala
+++ b/src/main/scala/Main.scala
@@ -20,18 +20,17 @@ object Main {
     val outputData = Section.groupItems(inputData)
     println(outputData)
 
-    //val testInput1 = "a bc defg"
-    //val testInput2 = "ltm node /Common/SL00300 {"
-    val testInput3 =
-    """
-      apm report default-report {
-    report-name sessionReports/sessionSummary
-    user /Common/admin
+    val testInput1 = "user /Common/admin"
+    val testInput2 =
+      """
+     availability-zone {
+            valid-values { a b c d }
+      }
 }""".stripMargin
-    //val testRun = Parser.run(testInput2)
-    //val testParserContent = Parser.content(new CharSequenceReader(testInput3))
-    val testParserContent = Parser.content(new CharSequenceReader(testInput3))
-    println(testParserContent)
+    val testSimpleContent = Parser.content(new CharSequenceReader(testInput1))
+    val testBlockContent = Parser.content(new CharSequenceReader(testInput2))
+    println(testSimpleContent)
+    println(testBlockContent)
 
     if(args.length == 0) {
       println("コマンドライン引数を与えて使ってね♡")

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -12,17 +12,18 @@ object Parser extends RegexParsers {  //RegexParsersトレイトを継承した�
   def names : Parser[List[String]] = name.*         //nameをリスト化（Parser[A] は、A 型の値を解析するためのパーサ）
   def run(text: String) : ParseResult[List[String]] = parse(names, text)  //textに対してnamesを実行。ParserResult[List[String]]型で返す。ParserResult[A]は、パーサによって処理された入力に対する結果を格納し、パースが成功したかどうか、失敗したかどうか、エラーが発生したかどうかを示す。
 
-  def simpleContent : Parser[String] = for {
-    //_ <- name <~ whiteSpace
-    _ <- name <~ """\s+""".r
-    content <- name <~ ("""(\n|\z)""".r)
-  } yield content.mkString  //fieldとcontentがシンプルに対になってる
-
-  def blockContent : Parser[String] = for {
-    _ <- name <~ """\s+""".r <~ elem('{')
-    content <- (name <~ elem('}')).*
-  } yield content.mkString("\n")    //contentが{}で囲まれてる
-
   def content : Parser[String] = simpleContent | blockContent
 
+  def field = name <~ whiteSpace <~ content
+
+  def simpleContent : Parser[String] = for {
+    _ <- name <~ whiteSpace
+    content <- name <~ ("""(\n|\z)""".r)
+  } yield content
+
+  def blockContent : Parser[String] = for {
+    '{' <~ eol
+     field* <~ eol
+      '}'
+  } yield content
 }

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -6,24 +6,24 @@
 import scala.util.parsing.combinator._  //パーサコンビネーターライブラリを使用するためのimport文
 import scala.util.matching.Regex  //正規表現を使用するためのimport文
 
-object Parser extends RegexParsers {  //RegexParsersトレイトを継承したオブジェクト(Parser)を作成
-  override def skipWhitespace =  false  //スペースをスキップ
-  def name : Regex =  """[0-9a-zA-Z/:_.,-]+""".r    //英数字記号の文字列を抽出
-  def names : Parser[List[String]] = name.*         //nameをリスト化（Parser[A] は、A 型の値を解析するためのパーサ）
-  def run(text: String) : ParseResult[List[String]] = parse(names, text)  //textに対してnamesを実行。ParserResult[List[String]]型で返す。ParserResult[A]は、パーサによって処理された入力に対する結果を格納し、パースが成功したかどうか、失敗したかどうか、エラーが発生したかどうかを示す。
+object Parser extends RegexParsers { //RegexParsersトレイトを継承したオブジェクト(Parser)を作成
+  override def skipWhitespace = true //スペースをスキップ
+  def name: Regex = """[0-9a-zA-Z/:_.,-]+""".r //英数字記号の文字列を抽出
+  def names: Parser[List[String]] = name.* //nameをリスト化（Parser[A] は、A 型の値を解析するためのパーサ）
+  def run(text: String): ParseResult[List[String]] = parse(names, text) //textに対してnamesを実行。ParserResult[List[String]]型で返す。ParserResult[A]は、パーサによって処理された入力に対する結果を格納し、パースが成功したかどうか、失敗したかどうか、エラーが発生したかどうかを示す。
 
-  def content : Parser[String] = simpleContent | blockContent
+  def content: Parser[String] = simpleContent | blockContent
 
   def field = name <~ whiteSpace <~ content
 
-  def simpleContent : Parser[String] = for {
+  def simpleContent: Parser[String] = for {
     _ <- name <~ whiteSpace
     content <- name <~ ("""(\n|\z)""".r)
   } yield content
 
-  def blockContent : Parser[String] = for {
-    '{' <~ eol
-     field* <~ eol
-      '}'
-  } yield content
+  def blockContent: Parser[String] = for {
+    _ <- '{' <~ """\n"""
+    content <- field.* <~ """\n"""
+    _ <- '}'
+  } yield content.mkString("\n")
 }

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -8,14 +8,21 @@ import scala.util.matching.Regex
 
 object Parser extends RegexParsers {
   override def skipWhitespace = true
-  def name: Regex =  """[0-9a-zA-Z/:-_.,]+""".r
-  def names: Parser[List[String]] = name.*
-  def run(text: String):ParseResult[List[String]] = parse(names, text)
+  def name : Regex =  """[0-9a-zA-Z/:-_.,]+""".r    //英数字記号の文字列を抽出
+  def names : Parser[List[String]] = name.*         //nameをリスト化
+  def run(text: String) : ParseResult[List[String]] = parse(names, text)  //textに対してnamesを実行
+  def simpleContent : Parser[(String, String)] = for {
+    user <- names <~ whiteSpace
+    content <- names <~ "\n"
+  }   //fieldとcontentがシンプルに対になってる
+  def blockContent : Parser[(String, String)] = ???      //contentが{}で囲まれてる
+  def content : Parser[String] = simpleContent | blockContent
+  /*def field : Parser[(String, String)]    //天才が作るやつ
   def item : Parser[(String, Item)] = for {
-    ns <- names <~ whiteSpace <~ elem('{') <~ "\n"
-    conts <- (Section.sectionItems <~ "\n").*
+    ns <- names <~ elem('{') <~ "\n"
+    fs <- (field <~ "\n").*
     _ <- elem('}')
   } yield {
-    (ns, conts)
-  }
+    (ns, fs)
+  }*/
 }

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -3,14 +3,14 @@
 正規表現：https://qiita.com/haryon0103/items/dffbe5333be1fc8a6908
  */
 
-import scala.util.parsing.combinator._
-import scala.util.matching.Regex
+import scala.util.parsing.combinator._  //パーサコンビネーターライブラリを使用するためのimport文
+import scala.util.matching.Regex  //正規表現を使用するためのimport文
 
-object Parser extends RegexParsers {
-  override def skipWhitespace = true
+object Parser extends RegexParsers {  //RegexParsersトレイトを継承したオブジェクト(Parser)を作成
+  override def skipWhitespace = true  //スペースをスキップ
   def name : Regex =  """[0-9a-zA-Z/:_.,-]+""".r    //英数字記号の文字列を抽出
-  def names : Parser[List[String]] = name.*         //nameをリスト化
-  def run(text: String) : ParseResult[List[String]] = parse(names, text)  //textに対してnamesを実行。ParserResult[List[String]]型で返す
+  def names : Parser[List[String]] = name.*         //nameをリスト化（Parser[A] は、A 型の値を解析するためのパーサ）
+  def run(text: String) : ParseResult[List[String]] = parse(names, text)  //textに対してnamesを実行。ParserResult[List[String]]型で返す。ParserResult[A]は、パーサによって処理された入力に対する結果を格納し、パースが成功したかどうか、失敗したかどうか、エラーが発生したかどうかを示す。
 
   def simpleContent : Parser[String] = for {
     field <- names <~ whiteSpace
@@ -22,19 +22,6 @@ object Parser extends RegexParsers {
     content <- (names <~ whiteSpace <~ elem('}')).*
   } yield content.mkString("\n")   //contentが{}で囲まれてる
 
-  def apply(input: String): String = parseAll(content, input) match {
-    case Success(result, _) => result
-    case Failure(msg, _) => s"Failure: $msg"
-    case Error(msg, _) => s"Error: $msg"
-  }
-
   def content : Parser[String] = simpleContent | blockContent
 
-  /*def item : Parser[(String, Item)] = for {
-    ns <- names <~ elem('{') <~ "\n"
-    fs <- (field <~ "\n").*
-    _ <- elem('}')
-  } yield {
-    (ns, fs)
-  }*/
 }

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -14,12 +14,12 @@ object Parser extends RegexParsers { //RegexParsersトレイトを継承した�
   def run(text: String): ParseResult[List[String]] = parse(names, text) //textに対してnamesを実行。ParserResult[List[String]]型で返す。ParserResult[A]は、パーサによって処理された入力に対する結果を格納し、パースが成功したかどうか、失敗したかどうか、エラーが発生したかどうかを示す。
   def content: Parser[String] = simpleContent | blockContent
   def field: Parser[String] = name ~> content
-    def simpleContent: Parser[String] = for {
-      content <- name
-    } yield content
-    def blockContent: Parser[String] = for {
-      _ <- literal("{")
-      content <- field.* //<~ eol
-      _ <- literal("}")
-    } yield content.mkString(" ")
+  def simpleContent: Parser[String] = for {
+    content <- name
+  } yield content
+  def blockContent: Parser[String] = for {
+    _ <- literal("{")
+    content <- field.* //<~ eol
+    _ <- literal("}")
+  } yield content.mkString(" ")
 }

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -11,12 +11,12 @@ object Parser extends RegexParsers {
   def name : Regex =  """[0-9a-zA-Z/:-_.,]+""".r    //英数字記号の文字列を抽出
   def names : Parser[List[String]] = name.*         //nameをリスト化
   def run(text: String) : ParseResult[List[String]] = parse(names, text)  //textに対してnamesを実行
-  def simpleContent : Parser[(List[String], List[String])] = for {
+  def simpleContent(lst : List[String]) : Parser[(List[String], List[String])] = for {
     field <- names <~ whiteSpace
     content <- names
     //_ <- "\n")
   } yield (field, content)  //fieldとcontentがシンプルに対になってる
-  def blockContent : Parser[(List[String], List[String])]  = for {
+  def blockContent(lst : List[String]) : Parser[(List[String], List[String])]  = for {
     field <- names <~ elem('{') <~ "\n"
     content <- names <~ "\n"
     _ <- elem('}')

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -12,13 +12,17 @@ object Parser extends RegexParsers {
   def names : Parser[List[String]] = name.*         //nameをリスト化
   def run(text: String) : ParseResult[List[String]] = parse(names, text)  //textに対してnamesを実行
   def simpleContent : Parser[(String, String)] = for {
-    user <- names <~ whiteSpace
+    field <- names <~ whiteSpace
     content <- names <~ "\n"
-  }   //fieldとcontentがシンプルに対になってる
-  def blockContent : Parser[(String, String)] = ???      //contentが{}で囲まれてる
-  def content : Parser[String] = simpleContent | blockContent
-  /*def field : Parser[(String, String)]    //天才が作るやつ
-  def item : Parser[(String, Item)] = for {
+    _ <- elem('}')
+  } yield (field, content)  //fieldとcontentがシンプルに対になってる
+  def blockContent : Parser[(String, String)] = for {
+    field <- names <~ elem('{') <~ "\n"
+    content <- names <~ "\n"
+    _ <- elem('}')
+  } yield (field, content)    //contentが{}で囲まれてる
+  def content : Parser[(String, String)] = simpleContent | blockContent
+  /*def item : Parser[(String, Item)] = for {
     ns <- names <~ elem('{') <~ "\n"
     fs <- (field <~ "\n").*
     _ <- elem('}')

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -7,21 +7,19 @@ import scala.util.parsing.combinator._  //パーサコンビネーターライ�
 import scala.util.matching.Regex  //正規表現を使用するためのimport文
 
 object Parser extends RegexParsers { //RegexParsersトレイトを継承したオブジェクト(Parser)を作成
-  override def skipWhitespace = true //スペースをスキップ
+  override def skipWhitespace = false//スペースをスキップ
+  def eol = "\n"
   def name: Regex = """[0-9a-zA-Z/:_.,-]+""".r //英数字記号の文字列を抽出
   def names: Parser[List[String]] = name.* //nameをリスト化（Parser[A] は、A 型の値を解析するためのパーサ）
   def run(text: String): ParseResult[List[String]] = parse(names, text) //textに対してnamesを実行。ParserResult[List[String]]型で返す。ParserResult[A]は、パーサによって処理された入力に対する結果を格納し、パースが成功したかどうか、失敗したかどうか、エラーが発生したかどうかを示す。
-
-  def content: Parser[String] = simpleContent | blockContent
-  def field: Parser[String] = name <~ whiteSpace <~ content
-
-  def simpleContent: Parser[String] = for {
-    content <- names
-  } yield content.mkString("\n")
-
-  def blockContent: Parser[String] = for {
-    _ <- '{' <~ """\n"""
-    content <- names <~ """\n"""
-    _ <- '}'
-  } yield content.mkString("\n")
+  def content: Parser[String] = blockContent | simpleContent
+  def field: Parser[String] = name ~> whiteSpace ~> content
+    def simpleContent: Parser[String] = for {
+      content <- name
+    } yield content
+    def blockContent: Parser[String] = for {
+      _  <- '{' <~ eol
+      content <- field.* <~ eol
+      _ <- '}'
+    } yield content.mkString(" ")
 }

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -7,19 +7,19 @@ import scala.util.parsing.combinator._  //パーサコンビネーターライ�
 import scala.util.matching.Regex  //正規表現を使用するためのimport文
 
 object Parser extends RegexParsers { //RegexParsersトレイトを継承したオブジェクト(Parser)を作成
-  override def skipWhitespace = false//スペースをスキップ
+  override def skipWhitespace = true//スペースをスキップ
   def eol = "\n"
   def name: Regex = """[0-9a-zA-Z/:_.,-]+""".r //英数字記号の文字列を抽出
   def names: Parser[List[String]] = name.* //nameをリスト化（Parser[A] は、A 型の値を解析するためのパーサ）
   def run(text: String): ParseResult[List[String]] = parse(names, text) //textに対してnamesを実行。ParserResult[List[String]]型で返す。ParserResult[A]は、パーサによって処理された入力に対する結果を格納し、パースが成功したかどうか、失敗したかどうか、エラーが発生したかどうかを示す。
-  def content: Parser[String] = blockContent | simpleContent
-  def field: Parser[String] = name ~> whiteSpace ~> content
+  def content: Parser[String] = simpleContent | blockContent
+  def field: Parser[String] = name ~> content
     def simpleContent: Parser[String] = for {
       content <- name
     } yield content
     def blockContent: Parser[String] = for {
-      _  <- '{' <~ eol
-      content <- field.* <~ eol
-      _ <- '}'
+      _ <- literal("{")
+      content <- field.* //<~ eol
+      _ <- literal("}")
     } yield content.mkString(" ")
 }

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -11,17 +11,17 @@ object Parser extends RegexParsers {
   def name : Regex =  """[0-9a-zA-Z/:-_.,]+""".r    //英数字記号の文字列を抽出
   def names : Parser[List[String]] = name.*         //nameをリスト化
   def run(text: String) : ParseResult[List[String]] = parse(names, text)  //textに対してnamesを実行
-  def simpleContent : Parser[(String, String)] = for {
+  def simpleContent : Parser[(List[String], List[String])] = for {
     field <- names <~ whiteSpace
-    content <- names <~ "\n"
-    _ <- elem('}')
+    content <- names
+    //_ <- "\n")
   } yield (field, content)  //fieldとcontentがシンプルに対になってる
-  def blockContent : Parser[(String, String)] = for {
+  def blockContent : Parser[(List[String], List[String])]  = for {
     field <- names <~ elem('{') <~ "\n"
     content <- names <~ "\n"
     _ <- elem('}')
   } yield (field, content)    //contentが{}で囲まれてる
-  def content : Parser[(String, String)] = simpleContent | blockContent
+  def content : Parser[(List[String], List[String])] = simpleContent | blockContent
   /*def item : Parser[(String, Item)] = for {
     ns <- names <~ elem('{') <~ "\n"
     fs <- (field <~ "\n").*

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -11,4 +11,11 @@ object Parser extends RegexParsers {
   def name: Regex =  """[0-9a-zA-Z/:-_.,]+""".r
   def names: Parser[List[String]] = name.*
   def run(text: String):ParseResult[List[String]] = parse(names, text)
+  def item : Parser[(String, Item)] = for {
+    ns <- names <~ whiteSpace <~ elem('{') <~ "\n"
+    conts <- (Section.sectionItems <~ "\n").*
+    _ <- elem('}')
+  } yield {
+    (ns, conts)
+  }
 }

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -10,15 +10,14 @@ object Parser extends RegexParsers {
   override def skipWhitespace = true
   def name : Regex =  """[0-9a-zA-Z/:-_.,]+""".r    //英数字記号の文字列を抽出
   def names : Parser[List[String]] = name.*         //nameをリスト化
-  def run(text: String) : ParseResult[List[String]] = parse(names, text)  //textに対してnamesを実行
-  def simpleContent(lst : List[String]) : Parser[(List[String], List[String])] = for {
+  def run(text: String) : ParseResult[List[String]] = parse(names, text)  //textに対してnamesを実行。ParserResult[List[String]]型で返す
+  def simpleContent : Parser[(List[String], List[String])] = for {
     field <- names <~ whiteSpace
-    content <- names
-    //_ <- "\n")
-  } yield (field, content)  //fieldとcontentがシンプルに対になってる
-  def blockContent(lst : List[String]) : Parser[(List[String], List[String])]  = for {
-    field <- names <~ elem('{') <~ "\n"
     content <- names <~ "\n"
+  } yield (field, List(content))  //fieldとcontentがシンプルに対になってる
+  def blockContent : Parser[(List[String], List[String])] = for {
+    field <- names <~ elem('{') <~ "\n"
+    content <- (names <~ "\n").*
     _ <- elem('}')
   } yield (field, content)    //contentが{}で囲まれてる
   def content : Parser[(List[String], List[String])] = simpleContent | blockContent

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -8,7 +8,7 @@ import scala.util.matching.Regex
 
 object Parser extends RegexParsers {
   override def skipWhitespace = true
-  def name : Regex =  """[0-9a-zA-Z/:-_.,]+""".r    //英数字記号の文字列を抽出
+  def name : Regex =  """[0-9a-zA-Z/:_.,-]+""".r    //英数字記号の文字列を抽出
   def names : Parser[List[String]] = name.*         //nameをリスト化
   def run(text: String) : ParseResult[List[String]] = parse(names, text)  //textに対してnamesを実行。ParserResult[List[String]]型で返す
 
@@ -18,10 +18,15 @@ object Parser extends RegexParsers {
   } yield content.mkString  //fieldとcontentがシンプルに対になってる
 
   def blockContent : Parser[String] = for {
-    field <- names <~ elem('{') <~ "\n"
-    content <- (names  <~ "\n").*
-    _ <- elem('}')
-  } yield content.mkString   //contentが{}で囲まれてる
+    field <- names <~ whiteSpace <~ elem('{') <~ "\n"
+    content <- (names <~ whiteSpace <~ elem('}')).*
+  } yield content.mkString("\n")   //contentが{}で囲まれてる
+
+  def apply(input: String): String = parseAll(content, input) match {
+    case Success(result, _) => result
+    case Failure(msg, _) => s"Failure: $msg"
+    case Error(msg, _) => s"Error: $msg"
+  }
 
   def content : Parser[String] = simpleContent | blockContent
 

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -7,21 +7,25 @@ import scala.util.parsing.combinator._  //パーサコンビネーターライ�
 import scala.util.matching.Regex  //正規表現を使用するためのimport文
 
 object Parser extends RegexParsers {  //RegexParsersトレイトを継承したオブジェクト(Parser)を作成
-  override def skipWhitespace = true  //スペースをスキップ
-  def name : Regex =  """[0-9a-zA-Z/:_.,-]+""".r    //英数字記号の文字列を抽出
+  //override def skipWhitespace = true  //スペースをスキップ
+  def name : Regex =  """[0-9a-zA-Z/:_.,\s\n-]+""".r    //英数字記号の文字列を抽出
   def names : Parser[List[String]] = name.*         //nameをリスト化（Parser[A] は、A 型の値を解析するためのパーサ）
   def run(text: String) : ParseResult[List[String]] = parse(names, text)  //textに対してnamesを実行。ParserResult[List[String]]型で返す。ParserResult[A]は、パーサによって処理された入力に対する結果を格納し、パースが成功したかどうか、失敗したかどうか、エラーが発生したかどうかを示す。
 
   def simpleContent : Parser[String] = for {
-    field <- names <~ whiteSpace
-    content <- names <~ "\n"
+    field <- names
+    content <- names
+    //field <- names <~ whiteSpace
+    //content <- names <~ "\n"
   } yield content.mkString  //fieldとcontentがシンプルに対になってる
 
   def blockContent : Parser[String] = for {
-    field <- names <~ whiteSpace <~ elem('{') <~ "\n"
-    content <- (names <~ whiteSpace <~ elem('}')).*
-  } yield content.mkString("\n")   //contentが{}で囲まれてる
-
+    field <- names <~ "{"
+    content <- (names <~ elem('}')).*
+    //field <- names <~ whiteSpace <~ elem('{') <~ "\n"
+    //content <- (names <~ elem('}')).*
+  } yield content.mkString   //contentが{}で囲まれてる
+  //} yield content.mkString("\n")   //contentが{}で囲まれてる
   def content : Parser[String] = simpleContent | blockContent
 
 }

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -11,16 +11,20 @@ object Parser extends RegexParsers {
   def name : Regex =  """[0-9a-zA-Z/:-_.,]+""".r    //英数字記号の文字列を抽出
   def names : Parser[List[String]] = name.*         //nameをリスト化
   def run(text: String) : ParseResult[List[String]] = parse(names, text)  //textに対してnamesを実行。ParserResult[List[String]]型で返す
-  def simpleContent : Parser[(List[String], List[String])] = for {
+
+  def simpleContent : Parser[String] = for {
     field <- names <~ whiteSpace
     content <- names <~ "\n"
-  } yield (field, List(content))  //fieldとcontentがシンプルに対になってる
-  def blockContent : Parser[(List[String], List[String])] = for {
+  } yield content.mkString  //fieldとcontentがシンプルに対になってる
+
+  def blockContent : Parser[String] = for {
     field <- names <~ elem('{') <~ "\n"
-    content <- (names <~ "\n").*
+    content <- (names  <~ "\n").*
     _ <- elem('}')
-  } yield (field, content)    //contentが{}で囲まれてる
-  def content : Parser[(List[String], List[String])] = simpleContent | blockContent
+  } yield content.mkString   //contentが{}で囲まれてる
+
+  def content : Parser[String] = simpleContent | blockContent
+
   /*def item : Parser[(String, Item)] = for {
     ns <- names <~ elem('{') <~ "\n"
     fs <- (field <~ "\n").*

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -7,25 +7,22 @@ import scala.util.parsing.combinator._  //パーサコンビネーターライ�
 import scala.util.matching.Regex  //正規表現を使用するためのimport文
 
 object Parser extends RegexParsers {  //RegexParsersトレイトを継承したオブジェクト(Parser)を作成
-  //override def skipWhitespace = true  //スペースをスキップ
-  def name : Regex =  """[0-9a-zA-Z/:_.,\s\n-]+""".r    //英数字記号の文字列を抽出
+  override def skipWhitespace =  false  //スペースをスキップ
+  def name : Regex =  """[0-9a-zA-Z/:_.,-]+""".r    //英数字記号の文字列を抽出
   def names : Parser[List[String]] = name.*         //nameをリスト化（Parser[A] は、A 型の値を解析するためのパーサ）
   def run(text: String) : ParseResult[List[String]] = parse(names, text)  //textに対してnamesを実行。ParserResult[List[String]]型で返す。ParserResult[A]は、パーサによって処理された入力に対する結果を格納し、パースが成功したかどうか、失敗したかどうか、エラーが発生したかどうかを示す。
 
   def simpleContent : Parser[String] = for {
-    field <- names
-    content <- names
-    //field <- names <~ whiteSpace
-    //content <- names <~ "\n"
+    //_ <- name <~ whiteSpace
+    _ <- name <~ """\s+""".r
+    content <- name <~ ("""(\n|\z)""".r)
   } yield content.mkString  //fieldとcontentがシンプルに対になってる
 
   def blockContent : Parser[String] = for {
-    field <- names <~ "{"
-    content <- (names <~ elem('}')).*
-    //field <- names <~ whiteSpace <~ elem('{') <~ "\n"
-    //content <- (names <~ elem('}')).*
-  } yield content.mkString   //contentが{}で囲まれてる
-  //} yield content.mkString("\n")   //contentが{}で囲まれてる
+    _ <- name <~ """\s+""".r <~ elem('{')
+    content <- (name <~ elem('}')).*
+  } yield content.mkString("\n")    //contentが{}で囲まれてる
+
   def content : Parser[String] = simpleContent | blockContent
 
 }

--- a/src/main/scala/Parser.scala
+++ b/src/main/scala/Parser.scala
@@ -13,17 +13,15 @@ object Parser extends RegexParsers { //RegexParsersトレイトを継承した�
   def run(text: String): ParseResult[List[String]] = parse(names, text) //textに対してnamesを実行。ParserResult[List[String]]型で返す。ParserResult[A]は、パーサによって処理された入力に対する結果を格納し、パースが成功したかどうか、失敗したかどうか、エラーが発生したかどうかを示す。
 
   def content: Parser[String] = simpleContent | blockContent
-
-  def field = name <~ whiteSpace <~ content
+  def field: Parser[String] = name <~ whiteSpace <~ content
 
   def simpleContent: Parser[String] = for {
-    _ <- name <~ whiteSpace
-    content <- name <~ ("""(\n|\z)""".r)
-  } yield content
+    content <- names
+  } yield content.mkString("\n")
 
   def blockContent: Parser[String] = for {
     _ <- '{' <~ """\n"""
-    content <- field.* <~ """\n"""
+    content <- names <~ """\n"""
     _ <- '}'
   } yield content.mkString("\n")
 }


### PR DESCRIPTION
<概要>

## 目的
Itemのコンテンツを１つパースする

## 確認方法
【インプット】 
val testInput1 = """user /Common/admin"""
    val testInput2 =
      """default-report {
    report-name sessionReports/sessionSummary
    user /Common/admin
    }"""

【アウトプット】
$ sbt
[info] Loading global plugins from C:\Users\user\.sbt\1.0\plugins
[info] Loading settings for project config-parse-build from plugins.sbt ...
[info] Loading project definition from C:\Users\user\work\config-parse\project
[info] Loading settings for project config-parse from build.sbt ...
[info] Set current project to config-parse (in build file:/C:/Users/user/work/config-parse/)
[info] sbt server started at local:sbt-server-9bb2ed34e65994607542
sbt:config-parse> ~run
[info] Running Main
Hello World
List(Section(foo,List(report-name, user),List(Item(default,Map(report-name -> Summary)), Item(report2,Map(report-name -> Common, user -> admin)))), Section(bar,List(rule),List(Item(monitor,Map(rule -> none)))))
/Common/admin
sessionReports/sessionSummary /Common/admin
コマンドライン引数を与えて使ってね♡
使用例: sbt "run sample/input/bigip.conf"


## 関連 issue (ある場合は)
* https://github.com/ichikawapc/config-parse/issues/42